### PR TITLE
chore: rename codebuild project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,3 @@ cdk.out
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-
-# Transpiled files
-lib/**/*.js
-lib/**/*.d.ts

--- a/README.md
+++ b/README.md
@@ -4,9 +4,25 @@ Tests npm ping on AWS CodeBuild
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
-## Useful commands
+## Setup
+
+- Run `yarn` to install dependencies.
+- Run `yarn cdk deploy` deploy this stack.
+- Visit `CodeBuildNpmPingTest*` project in CodeBuild AWS Console,
+  and click on `Start Build`.
+- Verify that the build succeeds, and the following output is displayed:
+
+  ```console
+  node version: v10.19.0
+
+  npm version: 6.13.4
+
+  { code: 0, signal: null }
+  ```
+
+- Run `yarn cdk destroy` destroy the stack.
+
+### Oher userful commands
 
 - `yarn cdk diff` compare deployed stack with current state
 - `yarn cdk synth` emits the synthesized CloudFormation template
-- `yarn cdk deploy` deploy this stack to your default AWS account/region
-- `yarn cdk destroy` destroys the stack from your default AWS account/region

--- a/lib/CodeBuildNpmPingTest.ts
+++ b/lib/CodeBuildNpmPingTest.ts
@@ -1,17 +1,23 @@
 import { Stack, StackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 export class CodeBuildNpmPingTest extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
+
+    const npmPingTestCode = readFileSync(resolve(__dirname, "npmPingTest.js"), {
+      encoding: "utf8",
+    });
 
     new codebuild.Project(this, "CodeBuildNpmPingTest", {
       buildSpec: codebuild.BuildSpec.fromObject({
         version: "0.2",
         phases: {
           build: {
-            commands: ['echo "Hello, CodeBuild!"'],
+            commands: [`node -e '${npmPingTestCode}'`],
           },
         },
       }),

--- a/lib/CodeBuildNpmPingTest.ts
+++ b/lib/CodeBuildNpmPingTest.ts
@@ -6,7 +6,7 @@ export class CodeBuildNpmPingTest extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    new codebuild.Project(this, "MyProject", {
+    new codebuild.Project(this, "CodeBuildNpmPingTest", {
       buildSpec: codebuild.BuildSpec.fromObject({
         version: "0.2",
         phases: {

--- a/lib/npmPingTest.js
+++ b/lib/npmPingTest.js
@@ -1,0 +1,14 @@
+const { execSync, spawn } = require("child_process");
+
+console.log("node version:", execSync("node -v", { encoding: "utf8" }));
+console.log("npm version:", execSync("npm -v", { encoding: "utf8" }));
+
+const npmPing = spawn("npm", ["ping"]);
+
+npmPing.on("error", (err) => {
+  console.error({ err });
+});
+
+npmPing.on("close", (code, signal) => {
+  console.log({ code, signal });
+});


### PR DESCRIPTION
Verified that the CodeBuild build succeeds, and the following output is displayed:

  ```console
  node version: v10.19.0

  npm version: 6.13.4

  { code: 0, signal: null }
  ```