### PR TITLE
chore: use codebuild.LinuxBuildImage.STANDARD_5_0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 - Verify that the build succeeds, and the following output is displayed:
 
   ```console
-  node version: v10.19.0
+  node version: v14.19.2
 
-  npm version: 6.13.4
+  npm version: 6.14.17
 
   { code: 0, signal: null }
   ```

--- a/lib/CodeBuildNpmPingTest.ts
+++ b/lib/CodeBuildNpmPingTest.ts
@@ -13,6 +13,9 @@ export class CodeBuildNpmPingTest extends Stack {
     });
 
     new codebuild.Project(this, "CodeBuildNpmPingTest", {
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.STANDARD_5_0,
+      },
       buildSpec: codebuild.BuildSpec.fromObject({
         version: "0.2",
         phases: {


### PR DESCRIPTION
Verified that the CodeBuild build succeeds, and the following output is displayed:

  ```console
  node version: v14.19.2

  npm version: 6.14.17

  { code: 0, signal: null }
  ```