### PR TITLE
chore: bump CodeBuild LinuxBuildImage to STANDARD_6_0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 - Verify that the build succeeds, and the following output is displayed:
 
   ```console
-  node version: v14.19.2
+  node version: v16.15.1
 
-  npm version: 6.14.17
+  npm version: 8.11.0
 
   { code: 0, signal: null }
   ```

--- a/lib/CodeBuildNpmPingTest.ts
+++ b/lib/CodeBuildNpmPingTest.ts
@@ -14,7 +14,7 @@ export class CodeBuildNpmPingTest extends Stack {
 
     new codebuild.Project(this, "CodeBuildNpmPingTest", {
       environment: {
-        buildImage: codebuild.LinuxBuildImage.STANDARD_5_0,
+        buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
       },
       buildSpec: codebuild.BuildSpec.fromObject({
         version: "0.2",


### PR DESCRIPTION
```console
$ yarn cdk diff
Stack CodeBuildNpmPingTest
Resources
[~] AWS::CodeBuild::Project CodeBuildNpmPingTest CodeBuildNpmPingTest6BB977A3 
 └─ [~] Environment
     └─ [~] .Image:
         ├─ [-] aws/codebuild/standard:5.0
         └─ [+] aws/codebuild/standard:6.0
         
$ yarn cdk deploy
...
 ✅  CodeBuildNpmPingTest

$ aws codebuild start-build --project-name CodeBuildNpmPingTest6BB977A3
```

Verified that CodeBuild run was successful:
```console
...
node version: v16.15.1
 
npm version: 8.11.0
 
{ code: 0, signal: null }
...
```